### PR TITLE
[ 機能追加 ] サイト一覧に表示順ソート機能を追加

### DIFF
--- a/src/views/site-list.php
+++ b/src/views/site-list.php
@@ -13,6 +13,16 @@ $s_author = isset( $_POST[ 's-author' ] ) ? array_map( 'sanitize_text_field', (a
 
 ////////// 関数定義 //////////
 
+// ソートキー
+$sort_key_array = [
+    'post_date.desc' => '公開日 降順',
+    'post_date.asc' => '公開日 昇順',
+    'post_modified.desc' => '更新日 降順',
+    'post_modified.asc' => '更新日 昇順',
+    'site_name.desc' => 'タイトル 降順',
+    'site_name.asc' => 'タイトル 昇順',
+];
+
 /**
  * サイト一覧の表示フィルタリング（検索条件の適用）
  * @param array $site サイト情報
@@ -324,6 +334,25 @@ echo '</div>';
 echo '</div>';
 echo '</div>'; // vkfsi_search-content
 
+// 検索フォーム - 表示順
+echo '<div class="vkfsi_search-item">';
+echo '<strong>表示順</strong>';
+echo '<ul class="vkfsi_input-wrap">';
+echo '<select name="s-sort" id="s-sort">';
+echo '<option value="">指定なし</option>';
+foreach ( $sort_key_array as $sort_key => $sort_name ) {
+    $selected = '';
+    if ( isset( $_POST[ 's-sort' ] ) && $sort_key == $_POST[ 's-sort' ] ) {
+        $selected = 'selected';
+    }
+    echo '<option value="' . esc_attr( $sort_key ) . '" ' . $selected . '>';
+    echo esc_html( $sort_name );
+    echo '</option>';
+}
+echo '</select>';
+echo '</ul>';
+echo '</div>';
+
 // 検索フォーム - 検索ボタン
 echo '<input type="submit" value="検索" class="button button-primary">';
 
@@ -361,6 +390,20 @@ if ( count( $filtered_sites ) == 0 ) {
     echo '<div class="notice notice-info is-dismissible"><p>該当するサイトが見つかりませんでした。</p></div>';
 } else {
     echo '<p>インストールするサイトを選択してください</p>';
+
+    // 表示順ソート
+    $sort_value = isset( $_POST[ 's-sort' ] ) ? sanitize_text_field( $_POST[ 's-sort' ] ) : '';
+    if ( $sort_value && isset( $sort_key_array[ $sort_value ] ) ) {
+        $sort_parts = explode( '.', $sort_value, 2 );
+        $sort_field = $sort_parts[0];
+        $sort_dir   = $sort_parts[1] ?? 'asc';
+        usort( $filtered_sites, function( $a, $b ) use ( $sort_field, $sort_dir ) {
+            $val_a = $a[ $sort_field ] ?? '';
+            $val_b = $b[ $sort_field ] ?? '';
+            $cmp   = strcmp( $val_a, $val_b );
+            return $sort_dir === 'desc' ? -$cmp : $cmp;
+        } );
+    }
 }
 
 // 検索条件用 hidden タグ

--- a/src/views/site-list.php
+++ b/src/views/site-list.php
@@ -400,7 +400,14 @@ if ( count( $filtered_sites ) == 0 ) {
         usort( $filtered_sites, function( $a, $b ) use ( $sort_field, $sort_dir ) {
             $val_a = $a[ $sort_field ] ?? '';
             $val_b = $b[ $sort_field ] ?? '';
-            $cmp   = strcmp( $val_a, $val_b );
+            // 日付フィールドは Unix タイムスタンプに変換して数値比較
+            if ( in_array( $sort_field, [ 'post_date', 'post_modified' ] ) ) {
+                $time_a = $val_a ? strtotime( $val_a ) : 0;
+                $time_b = $val_b ? strtotime( $val_b ) : 0;
+                $cmp    = $time_a <=> $time_b;
+            } else {
+                $cmp = strcmp( $val_a, $val_b );
+            }
             return $sort_dir === 'desc' ? -$cmp : $cmp;
         } );
     }


### PR DESCRIPTION
## 概要

サイト一覧画面の検索フォームに「表示順」セレクトボックスを追加し、以下の条件でソートできるようにしました。

- 公開日 降順 / 昇順
- 更新日 降順 / 昇順
- タイトル 降順 / 昇順

## 変更ファイル

- `src/views/site-list.php`

## 確認手順

### 前提条件

- fullsite-installer プラグインが有効化されていること
- サイト一覧に複数のサイトが表示される状態であること

### 手順

1. WordPress 管理画面から fullsite-installer の画面を開く
2. 検索フォームに「表示順」セレクトボックスが追加されていることを確認する
3. 「表示順」で「公開日 降順」を選択し、検索ボタンをクリックする
   → ✓ サイト一覧が公開日の新しい順に並び替えられる
4. 「表示順」で「公開日 昇順」を選択し、検索ボタンをクリックする
   → ✓ サイト一覧が公開日の古い順に並び替えられる
5. 「表示順」で「タイトル 昇順」を選択し、検索ボタンをクリックする
   → ✓ サイト一覧がタイトルのアルファベット/五十音順に並び替えられる
6. 「表示順」で「指定なし」を選択し、検索ボタンをクリックする
   → ✓ ソートが適用されず、元の順序で表示される
7. ソート条件と他の検索条件（テーマ・キーワードなど）を組み合わせて検索する
   → ✓ フィルタリング後の結果にソートが正しく適用される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * サイト一覧の検索に「表示順」ソート機能を追加しました。公開日・更新日・タイトルを基準に昇順／降順で並び替え可能で、検索フォーム内のドロップダウンから選択するだけで結果の順序をカスタマイズできます。デフォルトではソートは適用されません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/fullsite-installer/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->